### PR TITLE
fix: pass the runtime to the image recognition service

### DIFF
--- a/packages/client-discord/src/attachments.ts
+++ b/packages/client-discord/src/attachments.ts
@@ -291,7 +291,7 @@ export class AttachmentManager {
             const { description, title } = await this.runtime
                 .getService(ServiceType.IMAGE_DESCRIPTION)
                 .getInstance<IImageDescriptionService>()
-                .describeImage(attachment.url);
+                .describeImage(attachment.url, this.runtime);
             return {
                 id: attachment.id,
                 url: attachment.url,

--- a/packages/client-telegram/src/messageManager.ts
+++ b/packages/client-telegram/src/messageManager.ts
@@ -171,7 +171,7 @@ export class MessageManager {
             if (imageUrl) {
                 const { title, description } = await this.imageService
                     .getInstance()
-                    .describeImage(imageUrl);
+                    .describeImage(imageUrl, this.runtime);
                 const fullDescription = `[Image: ${title}\n${description}]`;
                 return { description: fullDescription };
             }

--- a/packages/client-twitter/src/search.ts
+++ b/packages/client-twitter/src/search.ts
@@ -239,7 +239,7 @@ export class TwitterSearchClient extends ClientBase {
                 const description = await this.runtime
                     .getService(ServiceType.IMAGE_DESCRIPTION)
                     .getInstance<IImageDescriptionService>()
-                    .describeImage(photo.url);
+                    .describeImage(photo.url, this.runtime);
                 imageDescriptions.push(description);
             }
 

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -853,7 +853,7 @@ export const generateCaption = async (
     const resp = await runtime
         .getService(ServiceType.IMAGE_DESCRIPTION)
         .getInstance<IImageDescriptionService>()
-        .describeImage(imageUrl);
+        .describeImage(imageUrl, runtime);
     return {
         title: resp.title.trim(),
         description: resp.description.trim(),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -595,7 +595,8 @@ export interface IImageDescriptionService extends Service {
     getInstance(): IImageDescriptionService;
     initialize(modelId?: string | null, device?: string | null): Promise<void>;
     describeImage(
-        imageUrl: string
+        imageUrl: string,
+        runtime: IAgentRuntime
     ): Promise<{ title: string; description: string }>;
 }
 

--- a/packages/plugin-node/src/services/image.ts
+++ b/packages/plugin-node/src/services/image.ts
@@ -87,8 +87,8 @@ export class ImageDescriptionService extends Service {
 
     async describeImage(
         imageUrl: string,
-        device?: string,
-        runtime?: IAgentRuntime
+        runtime: IAgentRuntime,
+        device?: string
     ): Promise<{ title: string; description: string }> {
         this.initialize(device, runtime);
 


### PR DESCRIPTION
If we don't pass the runtime it errors out when you send it an image, at least in Discord